### PR TITLE
[client] Add UnbufferedCollector

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -20,5 +20,21 @@
       <artifactId>common</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/client/src/main/java/rs/nicktrave/statsd/client/Collector.java
+++ b/client/src/main/java/rs/nicktrave/statsd/client/Collector.java
@@ -24,16 +24,14 @@ import rs.nicktrave.statsd.common.Metric;
 public interface Collector {
 
   /**
-   * Adds a new {@link Metric} to this collector.
+   * Adds {@link Metric}s to this collector.
    *
-   * @param metric the metric to add
+   * @param metrics the metrics to add
    */
-  void add(Metric metric);
+  void add(Metric ...metrics);
 
   /**
    * Flushes all held {@link Metric}s to an underlying {@link Transport}.
-   *
-   * @param transport the transport to flush the retained metrics to
    */
-  void flush(Transport transport);
+  void flush();
 }

--- a/client/src/main/java/rs/nicktrave/statsd/client/Transport.java
+++ b/client/src/main/java/rs/nicktrave/statsd/client/Transport.java
@@ -17,7 +17,6 @@ package rs.nicktrave.statsd.client;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import rs.nicktrave.statsd.common.Metric;
 
@@ -33,7 +32,7 @@ public interface Transport extends Closeable {
    * @param metrics the metrics to write
    * @throws IOException if one or more metrics could not be written
    */
-  void write(Collection<Metric> metrics) throws IOException;
+  void write(Metric ...metrics) throws IOException;
 
   /**
    * Attempts to close the transport within the specified time interval. If the close does not

--- a/client/src/main/java/rs/nicktrave/statsd/client/UnbufferedCollector.java
+++ b/client/src/main/java/rs/nicktrave/statsd/client/UnbufferedCollector.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2017 Nick Travers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rs.nicktrave.statsd.client;
+
+import java.io.IOException;
+import rs.nicktrave.statsd.common.Metric;
+
+/**
+ * A {@link Collector} that blocks waiting for the metric(s) to be flushed to the underlying
+ * transport.
+ */
+public class UnbufferedCollector implements Collector {
+
+  private final Transport transport;
+
+  /**
+   * Creates a new {@link Collector} that will perform a blocking write to the given transport as
+   * metrics are added.
+   *
+   * @param transport the transport to write to
+   */
+  public UnbufferedCollector(Transport transport) {
+    this.transport = transport;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This method performs a blocking write to the underlying transport.
+   */
+  @Override public void add(Metric... metrics) {
+    try {
+      transport.write(metrics);
+    } catch (IOException e) {
+      throw new RuntimeException("Could not flush metrics to transport", e);
+    }
+  }
+
+  /**
+   * An unbuffered collector can not be flushed directly, instead it is flushed as items are added
+   * to it.
+   */
+  @Override public void flush() {
+    throw new IllegalStateException("Can not call flush directly");
+  }
+}

--- a/client/src/test/java/rs/nicktrave/statsd/client/UnbufferedCollectorTest.java
+++ b/client/src/test/java/rs/nicktrave/statsd/client/UnbufferedCollectorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2017 Nick Travers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rs.nicktrave.statsd.client;
+
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import rs.nicktrave.statsd.common.Counter;
+import rs.nicktrave.statsd.common.Metric;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class UnbufferedCollectorTest {
+
+  private static final Metric METRIC_1 = new Counter("foo", 123);
+  private static final Metric METRIC_2 = new Counter("bar", 456);
+
+  @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock private Transport transport;
+  private UnbufferedCollector collector;
+
+  @Before public void setup() {
+    collector = new UnbufferedCollector(transport);
+  }
+
+  @Test public void testAdd() throws IOException {
+    collector.add(METRIC_1, METRIC_2);
+
+    verify(transport, times(1)).write(METRIC_1, METRIC_2);
+  }
+
+  @Test public void testAdd_transportThrows() throws IOException {
+    doThrow(IOException.class).when(transport).write(any(Metric.class));
+    assertThatThrownBy(() -> collector.add(METRIC_1, METRIC_2))
+        .hasCauseExactlyInstanceOf(IOException.class)
+        .hasMessage("Could not flush metrics to transport");
+  }
+
+  @Test public void testFlush() throws IOException {
+    assertThatThrownBy(() -> collector.flush())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Can not call flush directly");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
         <artifactId>assertj-core</artifactId>
         <version>3.8.0</version>
       </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>2.13.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>


### PR DESCRIPTION
Adds a Collector implementation that blocks writing to an underlying
transport as metrics are added to it.