### PR TITLE
[microbenchmarks] Add scaffolding

### DIFF
--- a/microbenchmarks/pom.xml
+++ b/microbenchmarks/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>rs.nicktrave.statsd</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>microbenchmarks</artifactId>
+  <name>Statsd Java :: Microbenchmarks</name>
+
+  <properties>
+    <!-- Skip tests by default; run only if -DskipTests=false is specified -->
+    <skipTests>true</skipTests>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Benchmarks are run as tests with code in the source directory -->
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <testSourceDirectory>${project.build.sourceDirectory}</testSourceDirectory>
+          <testClassesDirectory>${project.build.outputDirectory}</testClassesDirectory>
+          <excludes>
+            <exclude>**/AbstractMicrobenchmark.java</exclude>
+            <exclude>**/*$*.class</exclude>
+            <exclude>**/generated/*.class</exclude>
+          </excludes>
+          <systemPropertyVariables>
+            <perfReportDir>${project.build.directory}/reports/performance/</perfReportDir>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/microbenchmarks/src/main/java/rs/nicktrave/statsd/microbenchmarks/AbstractMicrobenchmarkBase.java
+++ b/microbenchmarks/src/main/java/rs/nicktrave/statsd/microbenchmarks/AbstractMicrobenchmarkBase.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2017 Nick Travers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rs.nicktrave.statsd.microbenchmarks;
+
+import io.netty.util.internal.SystemPropertyUtil;
+import java.io.File;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import static org.junit.Assert.assertNull;
+
+/**
+ * Base class for all JMH benchmarks.
+ *
+ * Inspiration shamelessly taken from:
+ * https://github.com/netty/netty/blob/4.1/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
+ */
+@Warmup(iterations = AbstractMicrobenchmarkBase.DEFAULT_WARMUP_ITERATIONS)
+@Measurement(iterations = AbstractMicrobenchmarkBase.DEFAULT_MEASURE_ITERATIONS)
+@State(Scope.Thread)
+public abstract class AbstractMicrobenchmarkBase {
+
+  protected static final int DEFAULT_WARMUP_ITERATIONS = 10;
+  protected static final int DEFAULT_MEASURE_ITERATIONS = 10;
+  protected static final String[] BASE_JVM_ARGS = {
+      "-XX:+AggressiveOpts", "-XX:+HeapDumpOnOutOfMemoryError"};
+
+  protected ChainedOptionsBuilder newOptionsBuilder() throws Exception {
+    String className = getClass().getSimpleName();
+
+    ChainedOptionsBuilder runnerOptions = new OptionsBuilder()
+        .include(".*" + className + ".*")
+        .jvmArgs(BASE_JVM_ARGS);
+
+    if (getWarmupIterations() > 0) {
+      runnerOptions.warmupIterations(getWarmupIterations());
+    }
+
+    if (getMeasureIterations() > 0) {
+      runnerOptions.measurementIterations(getMeasureIterations());
+    }
+
+    if (getReportDir() != null) {
+      String filePath = getReportDir() + className + ".json";
+      File file = new File(filePath);
+      if (file.exists()) {
+        file.delete();
+      } else {
+        file.getParentFile().mkdirs();
+        file.createNewFile();
+      }
+
+      runnerOptions.resultFormat(ResultFormatType.JSON);
+      runnerOptions.result(filePath);
+    }
+
+    return runnerOptions;
+  }
+
+  @Test
+  public void run() throws Exception {
+    new Runner(newOptionsBuilder().build()).run();
+  }
+
+  protected String[] jvmArgs() {
+    return BASE_JVM_ARGS;
+  }
+
+  protected int getWarmupIterations() {
+    return SystemPropertyUtil.getInt("warmupIterations", -1);
+  }
+
+  protected int getMeasureIterations() {
+    return SystemPropertyUtil.getInt("measureIterations", -1);
+  }
+
+  protected String getReportDir() {
+    return SystemPropertyUtil.get("perfReportDir");
+  }
+
+  public static void handleUnexpectedException(Throwable t) {
+    assertNull(t);
+  }
+}

--- a/microbenchmarks/src/main/java/rs/nicktrave/statsd/server/netty/DatagramToMetricDecoderTest.java
+++ b/microbenchmarks/src/main/java/rs/nicktrave/statsd/server/netty/DatagramToMetricDecoderTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2017 Nick Travers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rs.nicktrave.statsd.server.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.channel.socket.DatagramPacket;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import rs.nicktrave.statsd.microbenchmarks.AbstractMicrobenchmarkBase;
+
+@State(Scope.Benchmark)
+public class DatagramToMetricDecoderTest extends AbstractMicrobenchmarkBase {
+
+  private static final DatagramToMetricDecoder decoder = new DatagramToMetricDecoder();
+  private static final byte[] content = "foo:1234|c".getBytes(StandardCharsets.US_ASCII);
+  private static final ByteBuf buf = Unpooled.wrappedBuffer(content);
+  private static final InetSocketAddress address = new InetSocketAddress(42);
+
+  @Benchmark
+  public void test() throws Exception {
+    EmbeddedChannel embeddedChannel = new EmbeddedChannel(decoder);
+    embeddedChannel.writeInbound(new DatagramPacket(buf.copy(), address));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -23,16 +23,26 @@
   <modules>
     <module>common</module>
     <module>client</module>
+    <module>microbenchmarks</module>
     <module>server</module>
   </modules>
 
   <properties>
     <java.version>1.8</java.version>
+    <jmh.version>1.19</jmh.version>
     <netty.version>4.1.19.Final</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.5.0.Final</version>
+      </extension>
+    </extensions>
+
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -56,6 +66,16 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
         <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-core</artifactId>
+        <version>${jmh.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-generator-annprocess</artifactId>
+        <version>${jmh.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Add minimal benchmarking scaffolding via JMH, with inspiration taken
from Netty.

Add an initial benchmark to test the performance of the
DatagramToMetricDecoder.